### PR TITLE
Update `WeatherGetter` to use `WeatherStation`

### DIFF
--- a/app/services/weather/environment_canada/helpers/weather_getter.rb
+++ b/app/services/weather/environment_canada/helpers/weather_getter.rb
@@ -48,7 +48,10 @@ module Weather
         end
 
         def nearby_sites
-          @nearby_sites ||= CanadaSite.near(coordinate.to_a, 500).first(2) # Within 500km
+          @nearby_sites ||= WeatherStation
+            .within(radius: 500_000, of: coordinate.to_a)
+            .select(:code, :province, :location) # Within 500km
+            .first(2)
         end
 
         def closest_site


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR switches the Canada `WeatherGetter` so that it uses the new `WeatherStation` data, queried using PostGIS functions.

### Related issues or PRs
Follow up to #17

### How is this accomplished and why did you choose this approach?
N/A

### How to test changes
Ensure that you can still query for the weather.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [ ] I have tested this change on the `staging` server.
- [ ] I have added test cases, if needed.
- [x] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
