### PR TITLE
Fix issue where daily forecast could be shifted by a day (revised)

### DIFF
--- a/app/services/weather/environment_canada/factories/daily_factory.rb
+++ b/app/services/weather/environment_canada/factories/daily_factory.rb
@@ -14,6 +14,8 @@ module Weather
           input = forecasts
           return [] if @forecast_group.nil? || input.nil? || input.empty?
 
+          start_date = forecast_start_date(first_forecast: input.first)
+
           # Day condition should be nil if first item is night.
           input.unshift(nil) if night?(input.first)
 
@@ -21,7 +23,7 @@ module Weather
             day, night = pair
 
             Types::Daily.new(
-              time: time(index: index),
+              time: time(index: index, start_date: start_date),
               daytime_conditions: half_day_condition(forecast: day),
               nighttime_conditions: half_day_condition(forecast: night)
             )
@@ -34,17 +36,12 @@ module Weather
           @forecast_group&.xpath('forecast')&.to_a
         end
 
-        def forecast_issue_date
-          @forecast_group.xpath("dateTime[@name='forecastIssue' and @zone='UTC']/timeStamp").first&.content&.to_date
+        def forecast_start_date(first_forecast:)
+          period_name = first_forecast.xpath('period').first&.content
+          nearest_day(period_name: period_name)
         end
 
-        def time(index:)
-          today = Time.zone.today
-          yesterday = Time.zone.yesterday
-
-          starts_yesterday = forecast_issue_date.beginning_of_day == yesterday
-          start_date = starts_yesterday ? yesterday : today
-
+        def time(index:, start_date:)
           (start_date + index.day).to_time.to_i
         end
 
@@ -95,6 +92,35 @@ module Weather
 
         def night?(forecast)
           forecast.xpath("period[contains(text(), 'night')]").present?
+        end
+
+        def nearest_day(period_name:)
+          today = Time.zone.today
+          period_wday = weekday_index(period_name)
+
+          return today if period_wday == today.wday
+
+          weekday_name = symbol_for(weekday_index: period_wday)
+          next_weekday = Date.current.next_occurring(weekday_name)
+          previous_weekday = Date.current.prev_occurring(weekday_name)
+
+          if days_between(today, next_weekday) < days_between(today, previous_weekday)
+            next_weekday
+          else
+            previous_weekday
+          end
+        end
+
+        def weekday_index(string)
+          Date.parse(string).wday
+        end
+
+        def symbol_for(weekday_index:)
+          Date::DAYNAMES[weekday_index].downcase.to_sym
+        end
+
+        def days_between(first_date, second_date)
+          (first_date - second_date).abs.to_i
         end
       end
     end


### PR DESCRIPTION
### What is the problem being solved in this PR?

This PR fixes an issue where the daily forecast dates could be shifted by a day. This PR is a second attempt at the fix originally attempted in #25, but the code contained a bug where the logic to calculate the nearest weekday was incorrect. This PR contains a revised solution.

### Related issues or PRs

Resolves #23 
Resolves lfroms/clouds#72

### How is this accomplished and why did you choose this approach?

Previously, we were using the forecast issue date as the start date, but this resulted in cases where the forecast was incorrectly shifted. The new code finds the closest date to the first forecast's weekday name, and uses that as the start date.

### How to test changes

Difficult to test as this issue is not always present. During normal operation, the daily forecast should always make sense.

1. Launch the server using `rails s`.
2. Perform a GraphQL query for the weather.
3. Observe that the daily forecast dates are correct throughout the week.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] I have tested this change on the `staging` server.
- [ ] I have added test cases, if needed.
- [ ] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
